### PR TITLE
35 connect event pages to details pages

### DIFF
--- a/src/app/(frontend)/components/Events/event-tile.tsx
+++ b/src/app/(frontend)/components/Events/event-tile.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react'
 import { IEventTileProps } from '../../types/events'
 import styles from './events.module.css'
+import Link from 'next/link'
 
 const EventTile = ({ event }: IEventTileProps): ReactNode => {
   return (
@@ -14,11 +15,13 @@ const EventTile = ({ event }: IEventTileProps): ReactNode => {
         <h3>{event.title}</h3>
         <p className={styles.EventTileInfo}>{event.info}</p>
         <p>{event.location}</p>
+        <Link href="/events-details">
+          <button className={styles.EventTileView}>
+            <p>View</p>
 
-        <button className={styles.EventTileView}>
-          <p>View</p>
-          <img style={{ width: '16px' }} src="/images/chevron_right.png" alt="Right Arrow" />
-        </button>
+            <img style={{ width: '16px' }} src="/images/chevron_right.png" alt="Right Arrow" />
+          </button>
+        </Link>
       </div>
     </div>
   )

--- a/src/app/(frontend)/components/Events/event-tile.tsx
+++ b/src/app/(frontend)/components/Events/event-tile.tsx
@@ -15,7 +15,8 @@ const EventTile = ({ event }: IEventTileProps): ReactNode => {
         <h3>{event.title}</h3>
         <p className={styles.EventTileInfo}>{event.info}</p>
         <p>{event.location}</p>
-        <Link href="/events-details">
+        {/* Go to details page with event id apart of link */}
+        <Link href={`/events-details/${event.id}`}>
           <button className={styles.EventTileView}>
             <p>View</p>
 

--- a/src/app/(frontend)/components/Events/my-calendar.tsx
+++ b/src/app/(frontend)/components/Events/my-calendar.tsx
@@ -15,26 +15,30 @@ export default function MyCalendar({ events, showCalendar, setShowCalendar }: My
   const CustomToolbar = (toolbar: any) => {
     const month = moment(toolbar.date).format('MMMM').toUpperCase()
     return (
-      <div className='custom-toolbar-container'>
-        <div className='custom-toolbar'>
-          <button className="nav-arrow" onClick={() => toolbar.onNavigate('PREV')}>&lt;</button>
+      <div className="custom-toolbar-container">
+        <div className="custom-toolbar">
+          <button className="nav-arrow" onClick={() => toolbar.onNavigate('PREV')}>
+            &lt;
+          </button>
           <span className="month-label">{month}</span>
-          <button className="nav-arrow" onClick={() => toolbar.onNavigate('NEXT')}>&gt;</button>
+          <button className="nav-arrow" onClick={() => toolbar.onNavigate('NEXT')}>
+            &gt;
+          </button>
         </div>
-        
-        { showCalendar &&
+
+        {showCalendar && (
           <img
             src="/images/calendar-icon.png"
             alt="Toggle Calendar View"
             onClick={() => setShowCalendar(!showCalendar)}
           />
-        }
+        )}
       </div>
     )
   }
-    
+
   return (
-    <div className="calendar-container">    
+    <div className="calendar-container">
       <Calendar
         date={currentDate}
         onNavigate={(newDate: Date) => setCurrentDate(newDate)}
@@ -46,6 +50,12 @@ export default function MyCalendar({ events, showCalendar, setShowCalendar }: My
         views={['month']}
         style={{ height: 500 }}
         components={{ toolbar: CustomToolbar }}
+        onSelectEvent={(event: { id: string }) => {
+          window.location.href = `/events-details/0`
+          {
+            /*${event.id}`*/
+          }
+        }}
       />
     </div>
   )

--- a/src/app/(frontend)/components/Events/my-calendar.tsx
+++ b/src/app/(frontend)/components/Events/my-calendar.tsx
@@ -51,10 +51,7 @@ export default function MyCalendar({ events, showCalendar, setShowCalendar }: My
         style={{ height: 500 }}
         components={{ toolbar: CustomToolbar }}
         onSelectEvent={(event: { id: string }) => {
-          window.location.href = `/events-details/0`
-          {
-            /*${event.id}`*/
-          }
+          window.location.href = `/events-details/${event.id}`
         }}
       />
     </div>

--- a/src/app/(frontend)/events-details/[id]/page.tsx
+++ b/src/app/(frontend)/events-details/[id]/page.tsx
@@ -1,12 +1,16 @@
-import '../styles.css'
+import '../../styles.css'
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
+import { eventData } from '../../data/events'
 
-import { eventData } from '../data/events'
+interface EventDetailsParams {
+  params: { id: string }
+}
+export default function EventDetailsPage({ params }: EventDetailsParams) {
+  const id = parseInt(params.id, 10)
+  const event = eventData[id]
 
-export default function EventDetailsPage() {
-  const event = eventData[0]
   const dateStart = new Date(event.dateStart).toLocaleString('en-US', {
     weekday: 'short',
     day: '2-digit',
@@ -14,6 +18,7 @@ export default function EventDetailsPage() {
     hour: '2-digit',
     minute: '2-digit',
   })
+
   return (
     <div className="content-page">
       {/*copied top header*/}

--- a/src/app/(frontend)/events-details/page.tsx
+++ b/src/app/(frontend)/events-details/page.tsx
@@ -3,7 +3,17 @@ import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 
+import { eventData } from '../data/events'
+
 export default function EventDetailsPage() {
+  const event = eventData[0]
+  const dateStart = new Date(event.dateStart).toLocaleString('en-US', {
+    weekday: 'short',
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
   return (
     <div className="content-page">
       {/*copied top header*/}
@@ -29,22 +39,16 @@ export default function EventDetailsPage() {
           <div className="event-details-tile">
             <div className="event-details-tile-content">
               <div>
-                <h2>TUE 15 FEB @ 12:30AM</h2>
-                <h2>2ND FLOOR KATE EDGAR</h2>
+                <h2>{dateStart}</h2>
+                <h2>{event.location}</h2>
                 <h3>
-                  VROOM 2025 NEWS
+                  {event.title}
                   <p>Morbi molestie bibendum malesuada. Aenean vitae arcu consectetur.</p>
                 </h3>
                 <div className="event-details-line"></div>
                 <h4>
-                  VROOM 2025 NEWS
-                  <p>
-                    Morbi molestie bibendum malesuada. Aenean vitae arcu consectetur. Morbi molestie
-                    bibendum malesuada. Aenean vitae arcu consectetur. Morbi molestie bibendum
-                    malesuada. Aenean vitae arcu consectetur. Morbi molestie bibendum malesuada.
-                    Aenean vitae arcu consectetur. Morbi molestie bibendum malesuada. Aenean vitae
-                    arcu consectetur. Morbi molestie bibendum malesuada.
-                  </p>
+                  {event.title}
+                  <p>{event.info}</p>
                 </h4>
                 <a
                   className="event-details-form-link"

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -13,6 +13,7 @@ export default function EventsPage() {
     start: new Date(event.dateStart),
     end: new Date(event.dateEnd),
     title: event.title,
+    id: event.id,
   }))
 
   return (

--- a/src/app/(frontend)/types/events.ts
+++ b/src/app/(frontend)/types/events.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react"
+import { Dispatch, SetStateAction } from 'react'
 
 // Temp event object, will replace with a collection object once developed
 export type TEvent = {
@@ -29,20 +29,20 @@ export interface EventListViewProps {
 }
 
 export interface EventItem {
-    id: string;
-    title: string;
-    info: string;
-    imageUrl: string;
-    linkUrl: string;
+  id: string
+  title: string
+  info: string
+  imageUrl: string
+  linkUrl: string
 }
 
 export interface EventItemProps {
-    eventItem: EventItem;  
-    index: number;
+  eventItem: EventItem
+  index: number
 }
 
 export interface EventsBlockProps {
-    events: EventItem[];
+  events: EventItem[]
 }
 
 export interface IEventsProps {

--- a/src/app/(frontend)/types/events.ts
+++ b/src/app/(frontend)/types/events.ts
@@ -15,6 +15,7 @@ export interface CalendarEvent {
   start: Date
   end: Date
   title: string
+  id: string
 }
 
 export interface MyCalendarProps {


### PR DESCRIPTION
- Events page tiles correctly link to their respective details page upon clicking 'view' button
- Calendar View events correctly link to their respective details page upon clicking
- Event details page retrieves correct data for each event and displays it correctly with convention