### PR TITLE
50 add event and execs to payload cms

### DIFF
--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -3,8 +3,13 @@ import Description from '../components/about-us/Description'
 import { fakeExecs, fakeDescription } from '../data/execs'
 import '../styles.css'
 import Image from 'next/image'
-export default function AboutUsPage() {
+export default async function AboutUsPage() {
 
+  const res = await fetch(`${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/execs`, { cache: 'no-store' })
+  const data = await res.json()
+  const execs = data.docs
+
+  if (!execs) return <div>Loading execs...</div>
 
   return (
     <div className="content-page">
@@ -20,9 +25,9 @@ export default function AboutUsPage() {
         <Description desc={fakeDescription}/>
       </div>
       <div>
-        <ExecsSection title="LEADERSHIP" execs={fakeExecs} titleColour="#0078BE" />
-        <ExecsSection title="SOCIAL" execs={fakeExecs} titleColour="#F2C01F" />
-        <ExecsSection title="COMPETITIVE" execs={fakeExecs} titleColour="#EB534A" />
+        <ExecsSection title="LEADERSHIP" execs={execs} titleColour="#0078BE" />
+        <ExecsSection title="SOCIAL" execs={execs} titleColour="#F2C01F" />
+        <ExecsSection title="COMPETITIVE" execs={execs} titleColour="#EB534A" />
       </div>
     </div>
   )

--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -1,6 +1,6 @@
 import ExecsSection from '../components/about-us/ExecsSection'
 import Description from '../components/about-us/Description'
-import { fakeExecs, fakeDescription } from '../data/execs'
+import {fakeDescription } from '../data/execs'
 import '../styles.css'
 import Image from 'next/image'
 export default async function AboutUsPage() {
@@ -10,6 +10,12 @@ export default async function AboutUsPage() {
   const execs = data.docs
 
   if (!execs) return <div>Loading execs...</div>
+
+   // Filter execs by team
+  const leadershipExecs = execs.filter((exec: any) => exec.team === 'leadership')
+  const socialExecs = execs.filter((exec: any) => exec.team === 'social')
+  const competitiveExecs = execs.filter((exec: any) => exec.team === 'competitive')
+  const generalExecs = execs.filter((exec: any) => exec.team === 'general')
 
   return (
     <div className="content-page">
@@ -25,9 +31,10 @@ export default async function AboutUsPage() {
         <Description desc={fakeDescription}/>
       </div>
       <div>
-        <ExecsSection title="LEADERSHIP" execs={execs} titleColour="#0078BE" />
-        <ExecsSection title="SOCIAL" execs={execs} titleColour="#F2C01F" />
-        <ExecsSection title="COMPETITIVE" execs={execs} titleColour="#EB534A" />
+        <ExecsSection title="LEADERSHIP" execs={leadershipExecs} titleColour="#0078BE" />
+        <ExecsSection title="SOCIAL" execs={socialExecs} titleColour="#F2C01F" />
+        <ExecsSection title="COMPETITIVE" execs={competitiveExecs} titleColour="#EB534A" />
+        <ExecsSection title="GENERAL" execs={generalExecs} titleColour="#A2D300" />
       </div>
     </div>
   )

--- a/src/app/(frontend)/components/Events/event-list-view.tsx
+++ b/src/app/(frontend)/components/Events/event-list-view.tsx
@@ -5,13 +5,20 @@ import styles from './events.module.css'
 import { EventListViewProps, TEvent } from '../../types/events'
 
 const EventListView = ({ setShowCalendar, showCalendar, events }: EventListViewProps & { events: TEvent[] }) => {  
+  
+  const now = new Date()
+
+  const previousEvents = events.filter(event => new Date(event.dateEnd) < now)
+
+  const upcomingEvents = events.filter(event => new Date(event.dateEnd) >= now)
+  
   return (
     <section className={styles.EventMain}>
       <Header text="events" />
 
       <div className={styles.EventBody}>
-        <Events events={events} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="upcoming" />
-        <Events events={events} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="previous" />
+        <Events events={upcomingEvents} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="upcoming" />
+        <Events events={previousEvents} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="previous" />
       </div>
     </section>
   )

--- a/src/app/(frontend)/components/Events/event-list-view.tsx
+++ b/src/app/(frontend)/components/Events/event-list-view.tsx
@@ -2,16 +2,16 @@ import Header from './header'
 import Events from './events'
 
 import styles from './events.module.css'
-import { EventListViewProps } from '../../types/events'
+import { EventListViewProps, TEvent } from '../../types/events'
 
-const EventListView = ({ setShowCalendar, showCalendar }: EventListViewProps) => {  
+const EventListView = ({ setShowCalendar, showCalendar, events }: EventListViewProps & { events: TEvent[] }) => {  
   return (
     <section className={styles.EventMain}>
       <Header text="events" />
 
       <div className={styles.EventBody}>
-        <Events setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="upcoming" />
-        <Events setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="previous" />
+        <Events events={events} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="upcoming" />
+        <Events events={events} setShowCalendar={ setShowCalendar } showCalendar={ showCalendar} type="previous" />
       </div>
     </section>
   )

--- a/src/app/(frontend)/components/Events/events.tsx
+++ b/src/app/(frontend)/components/Events/events.tsx
@@ -2,35 +2,19 @@ import React, { ReactNode } from 'react'
 import styles from './events.module.css'
 import EventTile from './event-tile'
 import { eventData } from '../../data/events'
-import { IEventsProps } from '../../types/events'
+import { CalendarEvent, IEventsProps, TEvent } from '../../types/events'
 import LoadMore from './load-more'
 
 const UpcomingEventLimit = 3
 const PreviousEventLimit = 2
 
-const Events = ({ type, showCalendar, setShowCalendar }: IEventsProps): ReactNode => {
+interface EventsProps extends IEventsProps {
+  events: TEvent[]
+}
+
+const Events = ({ type, showCalendar, setShowCalendar, events }: EventsProps): ReactNode => {
   const title = type === 'upcoming' ? 'Upcoming Events' : 'Previous Events'
   const limit: number = type === 'upcoming' ? UpcomingEventLimit : PreviousEventLimit
-
-  const events = eventData.map((event) => {
-    // Format the date for display
-    const dateStart = new Date(event.dateStart).toLocaleString('en-US', {
-      weekday: 'short',
-      day: '2-digit',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-    return {
-      id: event.id,
-      title: event.title,
-      info: event.info,
-      imageUrl: event.imageUrl,
-      dateStart: dateStart,
-      dateEnd: event.dateEnd,
-      location: event.location,
-    }
-  })
 
   return (
     <section className={styles.Events}>

--- a/src/app/(frontend)/components/Events/my-calendar.tsx
+++ b/src/app/(frontend)/components/Events/my-calendar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Calendar, momentLocalizer } from 'react-big-calendar'
 import moment from 'moment'
-import { MyCalendarProps } from '../../types/events'
+import { CalendarEvent, MyCalendarProps } from '../../types/events'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
 import './style.css'
 
@@ -39,7 +39,7 @@ export default function MyCalendar({ events, showCalendar, setShowCalendar }: My
 
   return (
     <div className="calendar-container">
-      <Calendar
+      <Calendar<CalendarEvent>
         date={currentDate}
         onNavigate={(newDate: Date) => setCurrentDate(newDate)}
         localizer={localizer}

--- a/src/app/(frontend)/components/about-us/ExecsCard.tsx
+++ b/src/app/(frontend)/components/about-us/ExecsCard.tsx
@@ -6,8 +6,8 @@ export default function ExecsCard({ exec, index }: { exec: Exec; index: number }
   return (
     <div key={index} className={styles.execsCard}>
       <Image
-        src={exec.image}
-        alt={`${exec.name}'s photo`}
+        src={exec.photo?.url}
+        alt={exec.photo?.alt || `${exec.name}'s photo`}
         className={styles.execsImage}
         width={140}
         height={200}

--- a/src/app/(frontend)/data/execs.ts
+++ b/src/app/(frontend)/data/execs.ts
@@ -14,13 +14,3 @@ export const fakeDescription: DescriptionProps[] =[
     image: '/images/20250412_094454.jpg'
   }
 ] 
-export const fakeExecs: Exec[] = [
-    { name: 'John Doe', role: 'President', image: '/images/about-us/placeholderExec.png' },
-    { name: 'John Smith', role: 'Treasurer', image: '/images/about-us/placeholderExec.png' },
-    { name: 'Jane Doe', role: 'Events Lead', image: '/images/about-us/placeholderExec.png' },
-    { name: 'Jane Smith', role: 'Marketing Lead', image: '/images/about-us/placeholderExec.png' },
-    { name: 'Jim Doe', role: 'Social Lead', image: '/images/about-us/placeholderExec.png' },
-    { name: 'Jill Smith', role: 'Events Team', image: '/images/about-us/placeholderExec.png' },
-    { name: 'Josh Doe', role: 'General Team', image: '/images/about-us/placeholderExec.png' },
-    // { name: 'Jo Smith', role: 'General Team', image: '/images/about-us/placeholderExec.png' },
-  ]

--- a/src/app/(frontend)/events-details/[id]/page.tsx
+++ b/src/app/(frontend)/events-details/[id]/page.tsx
@@ -3,11 +3,10 @@ import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 
-interface EventDetailsParams {
-  params: { id: string }
-}
-export default async function EventDetailsPage({ params }: { params: { id: string } }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/events/${params.id}`, { cache: 'no-store' })
+
+export default async function EventDetailsPage({ params }: { params: Promise<{ id: string }> }) {
+  const awaitedParams = await params
+  const res = await fetch(`${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/events/${awaitedParams.id}`, { cache: 'no-store' })
   if (!res.ok) return <div>Event not found</div>
   const event = await res.json()
 

--- a/src/app/(frontend)/events-details/[id]/page.tsx
+++ b/src/app/(frontend)/events-details/[id]/page.tsx
@@ -2,14 +2,14 @@ import '../../styles.css'
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { eventData } from '../../data/events'
 
 interface EventDetailsParams {
   params: { id: string }
 }
-export default function EventDetailsPage(params: any) {
-  const id = parseInt(params.id, 10)
-  const event = eventData[id]
+export default async function EventDetailsPage({ params }: { params: { id: string } }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/events/${params.id}`, { cache: 'no-store' })
+  if (!res.ok) return <div>Event not found</div>
+  const event = await res.json()
 
   const dateStart = new Date(event.dateStart).toLocaleString('en-US', {
     weekday: 'short',

--- a/src/app/(frontend)/events-details/[id]/page.tsx
+++ b/src/app/(frontend)/events-details/[id]/page.tsx
@@ -7,7 +7,7 @@ import { eventData } from '../../data/events'
 interface EventDetailsParams {
   params: { id: string }
 }
-export default function EventDetailsPage({ params }: EventDetailsParams) {
+export default function EventDetailsPage(params: any) {
   const id = parseInt(params.id, 10)
   const event = eventData[id]
 

--- a/src/app/(frontend)/events/page.tsx
+++ b/src/app/(frontend)/events/page.tsx
@@ -9,7 +9,7 @@ import MyCalendar from '../components/Events/my-calendar'
 export default function EventsPage() {
   const [showCalendar, setShowCalendar] = useState(false)
 
-  const calendarData: CalendarEvent[] = eventData.map((event) => ({
+  const calendarData = eventData.map((event) => ({
     start: new Date(event.dateStart),
     end: new Date(event.dateEnd),
     title: event.title,

--- a/src/app/(frontend)/types/aboutus.ts
+++ b/src/app/(frontend)/types/aboutus.ts
@@ -1,7 +1,12 @@
+export interface ExecPhoto {
+  url: string
+  alt?: string
+}
+
 export interface Exec {
   name: string
   role: string
-  image: string // URL for the exec's image
+  photo: ExecPhoto
 }
 
 export interface ExecsSectionProps {

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,1 +1,5 @@
-export const importMap = {}
+
+
+export const importMap = {
+
+}

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -1,0 +1,51 @@
+import type { CollectionConfig } from 'payload'
+
+export const Events: CollectionConfig = {
+  slug: 'events',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'info',
+      type: 'textarea',
+      required: true,
+    },
+    {
+      name: 'dateStart',
+      type: 'date',
+      required: true,
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime', // shows both date and time
+        },
+      },
+    },
+    {
+      name: 'dateEnd',
+      type: 'date',
+      required: true,
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime', // shows both date and time
+        },
+      },
+    },
+    {
+      name: 'location',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'imageUrl',
+      type: 'text', // Or use 'upload' if you want to use Payload's media library
+      required: true,
+    },
+  ],
+}
+export default Events

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -5,6 +5,9 @@ export const Events: CollectionConfig = {
   admin: {
     useAsTitle: 'title',
   },
+  access: {
+    read: () => true, // allow public read access
+  },
   fields: [
     {
       name: 'title',

--- a/src/collections/Execs.ts
+++ b/src/collections/Execs.ts
@@ -5,6 +5,9 @@ export const Execs: CollectionConfig = {
   admin: {
     useAsTitle: 'name',
   },
+  access: {
+    read: () => true, // allow public read access
+  },
   fields: [
     {
       name: 'name',

--- a/src/collections/Execs.ts
+++ b/src/collections/Execs.ts
@@ -1,0 +1,26 @@
+import type { CollectionConfig } from 'payload'
+
+export const Execs: CollectionConfig = {
+  slug: 'execs',
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'role',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'photo',
+      type: 'upload',
+      relationTo: 'media', // assumes you have a 'media' collection
+    },
+  ],
+}
+export default Execs

--- a/src/collections/Execs.ts
+++ b/src/collections/Execs.ts
@@ -20,6 +20,18 @@ export const Execs: CollectionConfig = {
       required: true,
     },
     {
+      name: 'team', 
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Leadership', value: 'leadership' },
+        { label: 'Social', value: 'social' },
+        { label: 'Competitive', value: 'competitive' },
+        { label: 'General', value: 'general' },
+      ],
+      defaultValue: 'general',
+    },
+    {
       name: 'photo',
       type: 'upload',
       relationTo: 'media', // assumes you have a 'media' collection

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -176,6 +176,7 @@ export interface Exec {
   id: string;
   name: string;
   role: string;
+  team: 'leadership' | 'social' | 'competitive' | 'general';
   photo?: (string | null) | Media;
   updatedAt: string;
   createdAt: string;
@@ -299,6 +300,7 @@ export interface EventsSelect<T extends boolean = true> {
 export interface ExecsSelect<T extends boolean = true> {
   name?: T;
   role?: T;
+  team?: T;
   photo?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -69,6 +69,8 @@ export interface Config {
   collections: {
     users: User;
     media: Media;
+    events: Event;
+    execs: Exec;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -77,6 +79,8 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    events: EventsSelect<false> | EventsSelect<true>;
+    execs: ExecsSelect<false> | ExecsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -151,6 +155,33 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events".
+ */
+export interface Event {
+  id: string;
+  title: string;
+  info: string;
+  dateStart: string;
+  dateEnd: string;
+  location: string;
+  imageUrl: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "execs".
+ */
+export interface Exec {
+  id: string;
+  name: string;
+  role: string;
+  photo?: (string | null) | Media;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -163,6 +194,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'events';
+        value: string | Event;
+      } | null)
+    | ({
+        relationTo: 'execs';
+        value: string | Exec;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -238,6 +277,31 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "events_select".
+ */
+export interface EventsSelect<T extends boolean = true> {
+  title?: T;
+  info?: T;
+  dateStart?: T;
+  dateEnd?: T;
+  location?: T;
+  imageUrl?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "execs_select".
+ */
+export interface ExecsSelect<T extends boolean = true> {
+  name?: T;
+  role?: T;
+  photo?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -9,6 +9,8 @@ import sharp from 'sharp'
 
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
+import { Events } from './collections/Events'
+import { Execs } from './collections/Execs'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -20,7 +22,7 @@ export default buildConfig({
       baseDir: path.resolve(dirname),
     },
   },
-  collections: [Users, Media],
+  collections: [Users, Media, Events, Execs],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {


### PR DESCRIPTION
Events and execs are added to web page via /admin Payload API
- Events filtered based on previous or upcoming
- Execs filtered based on leadership team


These actual events and execs will need to be added next.