### PR TITLE
fix (ui): remove blank space on smaller screens

### DIFF
--- a/src/app/(frontend)/components/Home/LandingScreen.css
+++ b/src/app/(frontend)/components/Home/LandingScreen.css
@@ -43,7 +43,6 @@
     justify-content: center;
     align-items: center;
     gap: 2.5rem;
-    width: 100%; 
     padding: 0 2rem;
     z-index: 1;
 }


### PR DESCRIPTION
Modify home page CSS: remove blank space on smaller screens

<img width="501" height="751" alt="image" src="https://github.com/user-attachments/assets/2d830243-faeb-439c-b7b5-f9bca5978243" />
