### PR TITLE
feat: add order field to Execs for sorting exec list

### DIFF
--- a/src/collections/Execs.ts
+++ b/src/collections/Execs.ts
@@ -8,6 +8,7 @@ export const Execs: CollectionConfig = {
   access: {
     read: () => true, // allow public read access
   },
+  defaultSort: 'order',
   fields: [
     {
       name: 'name',
@@ -35,6 +36,22 @@ export const Execs: CollectionConfig = {
       name: 'photo',
       type: 'upload',
       relationTo: 'media', // assumes you have a 'media' collection
+    },
+    {
+      name: 'order',
+      type: 'select',
+      required: true,
+      admin: {
+        description: 'Sort priority (range 1–5, smaller numbers appear first)',
+      },
+      options: [
+        { label: '1', value: '1' },
+        { label: '2', value: '2' },
+        { label: '3', value: '3' },
+        { label: '4', value: '4' },
+        { label: '5', value: '5' },
+      ],
+      defaultValue: '5',
     },
   ],
 }


### PR DESCRIPTION
Adds a new `order` field to the Execs collection to allow custom sorting in the Admin UI.

### Details
- Added required `order` field of type string to Execs collection schema.
- Field is selection-based with allowed values `1–5`, and default value is `5`
- Added description in Admin UI: "Sort priority (range 1–5, smaller numbers appear first)".

### Acceptance Criteria
- [x] New `order` field is visible in Execs collection.
- [x] Default value is set to `5`.
- [x] Execs list sorts by `order` column by default.